### PR TITLE
Limit scheduled `pa_update_disp_cb` calls to one-at-a-time

### DIFF
--- a/src/pulse.c
+++ b/src/pulse.c
@@ -309,7 +309,7 @@ static void pa_cb_subscription (pa_context *, pa_subscription_event_type_t event
 #endif
     if (vol->bt_card_found == FALSE && newcard) vol->bt_card_found = TRUE;
 
-    vol->pa_idle_timer = g_idle_add (pa_update_disp_cb, vol);
+    if (vol->pa_idle_timer == 0) vol->pa_idle_timer = g_idle_add (pa_update_disp_cb, vol);
 
     pa_threaded_mainloop_signal (vol->pa_mainloop, 0);
 }


### PR DESCRIPTION
Before this change, each PulseAudio event was received using the `pa_cb_subscription` callback on the `pa_threaded_mainloop` thread, which then directly updated some variables and directly scheduled a `pa_update_disp_cb` call on the `GMainLoop` thread. The tag of that scheduled call was stored in `vol->pa_idle_timer`, so that the call could be canceled if the `vol` struct got freed before the call happened.

However, if PulseAudio events arrived in rapid succession, `vol->pa_idle_timer` would get overwritten, and some scheduled callbacks would fail to get canceled. Then when those callbacks ran, they would access memory that used to belong to `vol`, causing segmentation faults or unintended behavior.

This change solves the above problem by only scheduling a `pa_update_disp_cb` call when none is scheduled already. For thread-safety, this is done on the `GMainLoop` thread.

I have also moved the variable updating from the `pa_threaded_mainloop` thread to the `GMainLoop` thread, as it was not obvious to me that accessing `vol->bt_card_found` from the `pa_threaded_mainloop` is thread-safe.

Update 2025-11-25: To limit the changes, I have moved the processing back to the `pa_threaded_mainloop` thread, and instead protected `vol->pa_idle_timer` using the `pa_threaded_mainloop` lock. The unsafe access to `vol->bt_card_found` is no longer addressed in this PR.

Fixes: #10 